### PR TITLE
Additional check to stop error

### DIFF
--- a/AForge.WindowsForms/Form1.cs
+++ b/AForge.WindowsForms/Form1.cs
@@ -63,7 +63,7 @@ namespace AForge.WindowsForms
         private void btnStop_Click(object sender, EventArgs e)
         {
             videoSource.SignalToStop();
-            if (pictureBox1.Image != null)
+            if (videoSource != null && videoSource.IsRunning && pictureBox1.Image != null)
             {
                 pictureBox1.Image.Dispose();
             }


### PR DESCRIPTION
Check if video source is running before stopping. This was throwing out an error.